### PR TITLE
Made a simple header, useState for login is temporary

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,10 @@ import * as api from "@/utils/api";
 
 export default async function Home() {
   const movies = await api.getMovies();
-
+  const loggedIn: boolean = false;
   return (
     <main>
-      <Header />
+      <Header loggedIn={loggedIn} />
       {movies && <MovieList movies={movies}></MovieList>}
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,14 @@
 import MovieList from "@/components/MovieList";
+import Header from "@/components/Header";
 import * as api from "@/utils/api";
 
 export default async function Home() {
   const movies = await api.getMovies();
 
-  return <main>{movies && <MovieList movies={movies}></MovieList>}</main>;
+  return (
+    <main>
+      <Header />
+      {movies && <MovieList movies={movies}></MovieList>}
+    </main>
+  );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,11 @@
-"use client";
 import { FC } from "react";
-import { useState } from "react";
 import Link from "next/link";
 import LoginModal from "./LoginModal";
 import MyPages from "./MyPages";
 
-const Header: FC = () => {
-  //This useState is only temporary, remove this and put it as a prop
-  //once we start working on the login function
-  const [loggedIn, setLoggedIn] = useState<boolean>(false);
+//Still temporary code, will swap loggedIn for props from something like next-auth.
+//Probably with useSession to get session data
+const Header: FC<{ loggedIn: boolean }> = (loggedIn) => {
   return (
     <section>
       <header className="grid grid-cols-5 mt-6 ">
@@ -22,7 +19,7 @@ const Header: FC = () => {
           <Link href="/">Biljettinfo</Link>
         </ul>
 
-        {loggedIn ? <MyPages /> : <LoginModal />}
+        {loggedIn.loggedIn ? <MyPages /> : <LoginModal />}
       </header>
     </section>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { FC } from "react";
+import { useState } from "react";
+import Link from "next/link";
+import LoginModal from "./LoginModal";
+import MyPages from "./MyPages";
+
+const Header: FC = () => {
+  //This useState is only temporary, remove this and put it as a prop
+  //once we start working on the login function
+  const [loggedIn, setLoggedIn] = useState<boolean>(false);
+  return (
+    <section>
+      <header className="grid grid-cols-5 mt-6 ">
+        <Link className="order-first justify-start ml-10" href="/">
+          <img src="_next/static/public/Logo.png" alt="Spegeln Logo" />
+        </Link>
+
+        <ul className="flex flex-row col-start-2 col-end-5 text-xl font-semibold justify-center mt-6 gap-14">
+          <Link href="/">Öppettider & Kontakt</Link>
+          <Link href="/">Om Spegeln</Link>
+          <Link href="/">Biljettinfo</Link>
+        </ul>
+
+        {loggedIn ? <MyPages /> : <LoginModal />}
+      </header>
+    </section>
+  );
+};
+
+export default Header;

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,0 +1,11 @@
+import { FC } from "react";
+
+const LoginModal: FC = () => {
+  return (
+    <button className="order-last col-start-5 flex justify-end mr-10 mt-6 text-xl font-semibold">
+      Login/Register
+    </button>
+  );
+};
+
+export default LoginModal;

--- a/src/components/MyPages.tsx
+++ b/src/components/MyPages.tsx
@@ -1,0 +1,14 @@
+import { FC } from "react";
+import Link from "next/link";
+
+const MyPages: FC = () => {
+  return (
+    <Link
+      href="/"
+      className="order-last col-start-5 flex justify-end mr-10 mt-6 text-xl font-semibold">
+      USERNAME
+    </Link>
+  );
+};
+
+export default MyPages;


### PR DESCRIPTION
Created a simple enough header

- More simplistic design
- Removed the socials links since we won't be using them

Currently there is a useState in the Headercomponent. This will eventually be removed and replaced with a props from whatever code we writes that will handle logged in users. As for now it's only there to be able to swap between Login/My Pages button/link.

![Header preview](https://user-images.githubusercontent.com/100227467/235175500-69d578b8-a03a-4edc-b52f-48a26cb7e11f.png)

